### PR TITLE
feat: add unit tests for LlamaModel

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -41,8 +41,20 @@ add_executable(backend
         ${LLAMA_WRAPPER_SRCS} ${LLAMA_WRAPPER_HDRS}
         ${CONFIG_SRCS} ${CONFIG_HDRS}
         ${SERVICE_HDRS} ${SERVICE_SRCS}
-        main.cpp
-)
+        main.cpp)
 
 target_link_libraries(backend proto fmt llama)
 target_include_directories(backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(TEST_SRCS
+        llama/LlamaModel_test.cpp)
+
+add_executable(backend_test
+        ${CAPNP_WRAPPER_HDRS}
+        ${LLAMA_WRAPPER_SRCS} ${LLAMA_WRAPPER_HDRS}
+        ${CONFIG_SRCS} ${CONFIG_HDRS}
+        ${TEST_SRCS}
+)
+
+target_link_libraries(backend_test PRIVATE Catch2::Catch2WithMain proto llama)
+target_include_directories(backend_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/backend/llama/LlamaModel_test.cpp
+++ b/backend/llama/LlamaModel_test.cpp
@@ -1,0 +1,59 @@
+#include "catch2/catch_test_macros.hpp"
+
+#include "config/Config.h"
+#include "llama/LlamaModel.h"
+#include "llama/LlamaParams.h"
+#include "llama/LlamaScope.h"
+
+// Unit tests for LlamaModel
+
+TEST_CASE("The model loads correctly", "[llama][model]") {
+  // Build the model (llama-2-7b.Q4_0.gguf).
+  auto config = muton::playground::llm::Config::Read();
+  muton::playground::llm::LlamaScope scope(true);
+  muton::playground::llm::LlamaParams params(config->getParams());
+  muton::playground::llm::LlamaModel model(config->getModel().cStr(), params);
+  auto vocab = model.GetVocabulary();
+  SECTION("The model gets vocabulary correctly") {
+    // Test cases for LlamaModel::GetVocabulary():
+    // 1. The vocabulary size is 32000, that is, vocab.size == vocab.strings.size == vocab.scores.size == 32000.
+    REQUIRE(vocab.size == 32000);
+    REQUIRE(vocab.size == vocab.strings.size());
+    REQUIRE(vocab.size == vocab.scores.size());
+    // 2. The 0 token is <unk> with score 0.
+    REQUIRE(strcmp(vocab.strings[0], "<unk>") == 0);
+    REQUIRE(vocab.scores[0] == 0);
+    // 3. The 29902nd token is I with score -29643.
+    REQUIRE(strcmp(vocab.strings[29902], "I") == 0);
+    REQUIRE(vocab.scores[29902] == -29643);
+    // 4. The 5031st token is pat with score -4772.
+    REQUIRE(strcmp(vocab.strings[5031], "pat") == 0);
+    REQUIRE(vocab.scores[5031] == -4772);
+    // 5. The 8767th token is ubuntu with score -8508.
+    REQUIRE(strcmp(vocab.strings[8767], "ubuntu") == 0);
+    REQUIRE(vocab.scores[8767] == -8508);
+  }
+  SECTION("The model gets string from token correctly") {
+    // Test cases for LlamaModel::GetTokenString():
+    // 1. The 0 token is <unk>.
+    REQUIRE(strcmp(model.GetTokenString(0), "<unk>") == 0);
+    // 2. The 29902nd token is I.
+    REQUIRE(strcmp(model.GetTokenString(29902), "I") == 0);
+    // 3. The 5031st token is pat.
+    REQUIRE(strcmp(model.GetTokenString(5031), "pat") == 0);
+    // 4. The 8767th token is ubuntu.
+    REQUIRE(strcmp(model.GetTokenString(8767), "ubuntu") == 0);
+  }
+  SECTION("The model gets the begin of stream token correctly") {
+    // Test cases for LlamaModel::GetBos():
+    // 1. The begin of stream token is <s>.
+    REQUIRE(model.GetBos() == 1);
+    REQUIRE(strcmp(model.GetTokenString(model.GetBos()), "<s>") == 0);
+  }
+  SECTION("The model gets the end of stream token correctly") {
+    // Test cases for LlamaModel::GetEos():
+    // 1. The end of stream token is </s>.
+    REQUIRE(model.GetEos() == 2);
+    REQUIRE(strcmp(model.GetTokenString(model.GetEos()), "</s>") == 0);
+  }
+}


### PR DESCRIPTION
Add a unit test file backend/llama/LlamaModel_test.cpp for LlamaModel, including:
- LlamaModel::GetVocabulary()
- LlamaModel::GetTokenString()
- LlamaModel::GetBos()
- LlamaModel::GetEos()